### PR TITLE
remove user summary put and post APIs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,12 +15,12 @@ import {
     isLoggedIn,
     setName,
     checkIfNameChanged,
-    getPluginName,
-    getVersion
 } from "./utils/Util";
+import { getPluginName, getVersion } from "./utils/PluginUtil";
 import { commands } from "vscode";
 import { TrackerManager } from "./managers/TrackerManager";
 import { MilestoneEventManager } from "./managers/MilestoneEventManager";
+import { fetchSummary } from "./utils/SummaryDbUtil";
 
 const tracker: TrackerManager = TrackerManager.getInstance();
 
@@ -75,6 +75,8 @@ export async function initializePlugin() {
 
         // clean up unused files
         deleteLogsPayloadJson();
+
+        fetchSummary();
     }
 
     // initialize tracker

--- a/src/managers/HttpManager.ts
+++ b/src/managers/HttpManager.ts
@@ -1,11 +1,21 @@
 import axios from "axios";
 import { api_endpoint } from "../utils/Constants";
+import { getPluginId, getPluginName, getVersion, getOs, getOffsetSeconds } from "../utils/PluginUtil";
 
 // build the axios api base url
 const beApi = axios.create({
     baseURL: `${api_endpoint}`,
     timeout: 8000
 });
+
+beApi.defaults.headers.common["X-SWDC-Plugin-Id"] = getPluginId();
+beApi.defaults.headers.common["X-SWDC-Plugin-Name"] = getPluginName();
+beApi.defaults.headers.common["X-SWDC-Plugin-Version"] = getVersion();
+beApi.defaults.headers.common["X-SWDC-Plugin-OS"] = getOs();
+beApi.defaults.headers.common[
+    "X-SWDC-Plugin-TZ"
+] = Intl.DateTimeFormat().resolvedOptions().timeZone;
+beApi.defaults.headers.common["X-SWDC-Plugin-Offset"] = getOffsetSeconds() / 60;
 
 export async function serverIsAvailable() {
     return await softwareGet("/ping")

--- a/src/managers/TrackerManager.ts
+++ b/src/managers/TrackerManager.ts
@@ -1,7 +1,7 @@
 import swdcTracker from "swdc-tracker";
 import { api_endpoint } from "../utils/Constants";
 import { getJwt } from "../utils/Util";
-import { getPluginId, getPluginName, getVersion } from "../utils/Util";
+import { getPluginId, getPluginName, getVersion } from "../utils/PluginUtil";
 
 export class TrackerManager {
 	private static instance: TrackerManager;
@@ -53,7 +53,7 @@ export class TrackerManager {
 			plugin_id: getPluginId(),
 			plugin_name: getPluginName(),
 			plugin_version: getVersion()
-		}
+		};
 
 		swdcTracker.trackUIInteraction(payload)
 	}

--- a/src/utils/PluginUtil.ts
+++ b/src/utils/PluginUtil.ts
@@ -1,0 +1,45 @@
+import { extensions } from "vscode";
+import { _100_DAYS_OF_CODE_EXT_ID, _100_DAYS_OF_CODE_PLUGIN_ID } from "./Constants";
+const os = require("os");
+
+export function getPluginId() {
+	return _100_DAYS_OF_CODE_PLUGIN_ID;
+}
+
+export function getPluginName() {
+	return _100_DAYS_OF_CODE_EXT_ID;
+}
+
+export function getVersion() {
+	const extension = extensions.getExtension(_100_DAYS_OF_CODE_EXT_ID);
+	if (extension) {
+			return extension.packageJSON.version;
+	} else {
+			return;
+	}
+}
+
+export function getOs() {
+	let parts = [];
+	let osType = os.type();
+	if (osType) {
+			parts.push(osType);
+	}
+	let osRelease = os.release();
+	if (osRelease) {
+			parts.push(osRelease);
+	}
+	let platform = os.platform();
+	if (platform) {
+			parts.push(platform);
+	}
+	if (parts.length > 0) {
+			return parts.join("_");
+	}
+	return "";
+}
+
+export function getOffsetSeconds() {
+	let d = new Date();
+	return d.getTimezoneOffset() * 60;
+}

--- a/src/utils/SummaryDbUtil.ts
+++ b/src/utils/SummaryDbUtil.ts
@@ -1,56 +1,10 @@
 import { compareLocalSummary } from "./SummaryUtil";
-import { Summary } from "../models/Summary";
-import { softwarePost, softwarePut, softwareGet, isResponseOk } from "../managers/HttpManager";
+import { softwareGet, isResponseOk } from "../managers/HttpManager";
 import { getItem } from "./Util";
-import { fetchSummaryJsonFileData } from "../managers/FileManager";
 
-export async function pushNewSummary() {
-    // get the summary from the JSON
-    const summary: Summary = fetchSummaryJsonFileData();
-
-    // convert the summary object to the db style object
-    const toCreateSummary = {
-        days: summary.days,
-        minutes: summary.hours * 60,
-        keystrokes: summary.keystrokes,
-        lines_added: summary.lines_added,
-        lines_removed: 0,
-        longest_streak: summary.longest_streak,
-        milestones: summary.milestones,
-        shares: summary.shares,
-        languages: summary.languages
-    };
+export async function fetchSummary() {
     const jwt = getItem("jwt");
     if (jwt) {
-        await softwarePost("/100doc/summary", toCreateSummary, jwt);
-    }
-}
-
-export async function pushUpdatedSummary() {
-    const summary: Summary = fetchSummaryJsonFileData();
-
-    const toCreateSummary = {
-        days: summary.days,
-        minutes: summary.hours * 60,
-        keystrokes: summary.keystrokes,
-        lines_added: summary.lines_added,
-        lines_removed: 0,
-        longest_streak: summary.longest_streak,
-        milestones: summary.milestones,
-        shares: summary.shares,
-        languages: summary.languages
-    };
-
-    const jwt = getItem("jwt");
-    if (jwt) {
-        softwarePut("/100doc/summary", toCreateSummary, jwt);
-    }
-}
-
-export async function fetchSummary(): Promise<boolean> {
-    const jwt = getItem("jwt");
-    if (jwt) {
-
         const summary = await softwareGet("/100doc/summary", jwt).then(resp => {
             if (isResponseOk(resp) && resp.data) {
                 const rawSummary = resp.data;
@@ -69,8 +23,6 @@ export async function fetchSummary(): Promise<boolean> {
         });
         if (summary) {
             compareLocalSummary(summary);
-            return true;
         }
     }
-    return false;
 }

--- a/src/utils/Util.ts
+++ b/src/utils/Util.ts
@@ -16,23 +16,6 @@ let current_check_login_interval_count = 0;
 let checking_login = false;
 let _name = "";
 
-export function getPluginId() {
-    return _100_DAYS_OF_CODE_PLUGIN_ID;
-}
-
-export function getPluginName() {
-    return _100_DAYS_OF_CODE_EXT_ID;
-}
-
-export function getVersion() {
-    const extension = extensions.getExtension(_100_DAYS_OF_CODE_EXT_ID);
-    if (extension) {
-        return extension.packageJSON.version;
-    } else {
-        return;
-    }
-}
-
 async function wrapExecPromise(cmd: string, projectDir: null | undefined) {
     let result = null;
     try {
@@ -256,4 +239,8 @@ export function checkIfNameChanged() {
     } else {
         return false;
     }
+}
+
+export function mergeArrays(array1: Array<any>, array2: Array<any>) {
+    return [...new Set({...array1 || [], ...array2 || []})];
 }


### PR DESCRIPTION
the backend will send the user summary info from snowflake, which will summarize what the user has accomplished without having to save it in the user_summaries table